### PR TITLE
Accessory hermetyzacja

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+target/
+bin/
+.idea/
+*.class

--- a/src/main/java/edu/kis/vh/nursery/DefaultCountingOutRhymer.java
+++ b/src/main/java/edu/kis/vh/nursery/DefaultCountingOutRhymer.java
@@ -1,6 +1,6 @@
 package edu.kis.vh.nursery;
 
-public class defaultCountingOutRhymer {
+public class DefaultCountingOutRhymer {
 
     private int[] numbers = new int[12];
 

--- a/src/main/java/edu/kis/vh/nursery/DefaultCountingOutRhymer.java
+++ b/src/main/java/edu/kis/vh/nursery/DefaultCountingOutRhymer.java
@@ -4,6 +4,10 @@ public class DefaultCountingOutRhymer {
 
     private int[] numbers = new int[12];
 
+    public int getTotal() {
+        return total;
+    }
+
     private int total = -1;
 
     public void countIn(int in) {

--- a/src/main/java/edu/kis/vh/nursery/DefaultCountingOutRhymer.java
+++ b/src/main/java/edu/kis/vh/nursery/DefaultCountingOutRhymer.java
@@ -4,7 +4,7 @@ public class DefaultCountingOutRhymer {
 
     private int[] numbers = new int[12];
 
-    public int total = -1;
+    private int total = -1;
 
     public void countIn(int in) {
         if (!isFull())

--- a/src/main/java/edu/kis/vh/nursery/FIFORhymer.java
+++ b/src/main/java/edu/kis/vh/nursery/FIFORhymer.java
@@ -3,19 +3,17 @@ package edu.kis.vh.nursery;
 public class FIFORhymer extends defaultCountingOutRhymer {
 
     public defaultCountingOutRhymer temp = new defaultCountingOutRhymer();
-    
+
     @Override
     public int countOut() {
         while (!callCheck())
-            
-        temp.countIn(super.countOut());
-        
+            temp.countIn(super.countOut());
+
         int ret = temp.countOut();
-        
+
         while (!temp.callCheck())
-            
-        countIn(temp.countOut());
-        
+            countIn(temp.countOut());
+
         return ret;
     }
 }

--- a/src/main/java/edu/kis/vh/nursery/FIFORhymer.java
+++ b/src/main/java/edu/kis/vh/nursery/FIFORhymer.java
@@ -2,7 +2,7 @@ package edu.kis.vh.nursery;
 
 public class FIFORhymer extends DefaultCountingOutRhymer {
 
-    public DefaultCountingOutRhymer temp = new DefaultCountingOutRhymer();
+    private DefaultCountingOutRhymer temp = new DefaultCountingOutRhymer();
 
     @Override
     public int countOut() {

--- a/src/main/java/edu/kis/vh/nursery/FIFORhymer.java
+++ b/src/main/java/edu/kis/vh/nursery/FIFORhymer.java
@@ -1,8 +1,8 @@
 package edu.kis.vh.nursery;
 
-public class FIFORhymer extends defaultCountingOutRhymer {
+public class FIFORhymer extends DefaultCountingOutRhymer {
 
-    public defaultCountingOutRhymer temp = new defaultCountingOutRhymer();
+    public DefaultCountingOutRhymer temp = new DefaultCountingOutRhymer();
 
     @Override
     public int countOut() {

--- a/src/main/java/edu/kis/vh/nursery/HanoiRhymer.java
+++ b/src/main/java/edu/kis/vh/nursery/HanoiRhymer.java
@@ -1,6 +1,6 @@
 package edu.kis.vh.nursery;
 
-public class HanoiRhymer extends defaultCountingOutRhymer {
+public class HanoiRhymer extends DefaultCountingOutRhymer {
 
     int totalRejected = 0;
 

--- a/src/main/java/edu/kis/vh/nursery/HanoiRhymer.java
+++ b/src/main/java/edu/kis/vh/nursery/HanoiRhymer.java
@@ -2,7 +2,7 @@ package edu.kis.vh.nursery;
 
 public class HanoiRhymer extends DefaultCountingOutRhymer {
 
-    int totalRejected = 0;
+    private int totalRejected = 0;
 
     public int reportRejected() {
         return totalRejected;

--- a/src/main/java/edu/kis/vh/nursery/HanoiRhymer.java
+++ b/src/main/java/edu/kis/vh/nursery/HanoiRhymer.java
@@ -9,9 +9,9 @@ public class HanoiRhymer extends defaultCountingOutRhymer {
     }
 
     public void countIn(int in) {
-    if (!callCheck() && in > peekaboo())
-        totalRejected++;
-    else
-        super.countIn(in);
+        if (!callCheck() && in > peekaboo())
+            totalRejected++;
+        else
+            super.countIn(in);
     }
 }

--- a/src/main/java/edu/kis/vh/nursery/HanoiRhymer.java
+++ b/src/main/java/edu/kis/vh/nursery/HanoiRhymer.java
@@ -2,7 +2,7 @@ package edu.kis.vh.nursery;
 
 public class HanoiRhymer extends defaultCountingOutRhymer {
 
-int totalRejected = 0;
+    int totalRejected = 0;
 
     public int reportRejected() {
         return totalRejected;
@@ -10,8 +10,8 @@ int totalRejected = 0;
 
     public void countIn(int in) {
     if (!callCheck() && in > peekaboo())
-            totalRejected++;
-            else
-                super.countIn(in);
+        totalRejected++;
+    else
+        super.countIn(in);
     }
 }

--- a/src/main/java/edu/kis/vh/nursery/defaultCountingOutRhymer.java
+++ b/src/main/java/edu/kis/vh/nursery/defaultCountingOutRhymer.java
@@ -2,13 +2,13 @@ package edu.kis.vh.nursery;
 
 public class defaultCountingOutRhymer {
 
-    private int[] NUMBERS = new int[12];
+    private int[] numbers = new int[12];
 
     public int total = -1;
 
     public void countIn(int in) {
         if (!isFull())
-            NUMBERS[++total] = in;
+            numbers[++total] = in;
     }
 
     public boolean callCheck() {
@@ -22,13 +22,13 @@ public class defaultCountingOutRhymer {
     protected int peekaboo() {
         if (callCheck())
             return -1;
-        return NUMBERS[total];
+        return numbers[total];
     }
 
     public int countOut() {
         if (callCheck())
             return -1;
-        return NUMBERS[total--];
+        return numbers[total--];
     }
 
 }

--- a/src/main/java/edu/kis/vh/nursery/defaultCountingOutRhymer.java
+++ b/src/main/java/edu/kis/vh/nursery/defaultCountingOutRhymer.java
@@ -11,24 +11,24 @@ public class defaultCountingOutRhymer {
             NUMBERS[++total] = in;
     }
 
-        public boolean callCheck() {
-            return total == -1;
-        }
-        
-            public boolean isFull() {
-                return total == 11;
-            }
-        
-                protected int peekaboo() {
-                    if (callCheck())
-                        return -1;
-                    return NUMBERS[total];
-                }
-            
-                    public int countOut() {
-                        if (callCheck())
-                            return -1;
-                        return NUMBERS[total--];
-                    }
+    public boolean callCheck() {
+        return total == -1;
+    }
+
+    public boolean isFull() {
+        return total == 11;
+    }
+
+    protected int peekaboo() {
+        if (callCheck())
+            return -1;
+        return NUMBERS[total];
+    }
+
+    public int countOut() {
+        if (callCheck())
+            return -1;
+        return NUMBERS[total--];
+    }
 
 }

--- a/src/main/java/edu/kis/vh/nursery/factory/DefaultRhymersFactory.java
+++ b/src/main/java/edu/kis/vh/nursery/factory/DefaultRhymersFactory.java
@@ -8,22 +8,22 @@ import edu.kis.vh.nursery.factory.Rhymersfactory;
 public class DefaultRhymersFactory implements Rhymersfactory {
 
     @Override
-    public defaultCountingOutRhymer GetStandardRhymer() {
+    public defaultCountingOutRhymer getStandardRhymer() {
         return new defaultCountingOutRhymer();
     }
 
     @Override
-    public defaultCountingOutRhymer GetFalseRhymer() {
+    public defaultCountingOutRhymer getFalseRhymer() {
         return new defaultCountingOutRhymer();
     }
 
     @Override
-    public defaultCountingOutRhymer GetFIFORhymer() {
+    public defaultCountingOutRhymer getFIFORhymer() {
         return new FIFORhymer();
     }
 
     @Override
-    public defaultCountingOutRhymer GetHanoiRhymer() {
+    public defaultCountingOutRhymer getHanoiRhymer() {
         return new HanoiRhymer();
     }
 

--- a/src/main/java/edu/kis/vh/nursery/factory/DefaultRhymersFactory.java
+++ b/src/main/java/edu/kis/vh/nursery/factory/DefaultRhymersFactory.java
@@ -1,6 +1,6 @@
 package edu.kis.vh.nursery.factory;
 
-import edu.kis.vh.nursery.defaultCountingOutRhymer;
+import edu.kis.vh.nursery.DefaultCountingOutRhymer;
 import edu.kis.vh.nursery.FIFORhymer;
 import edu.kis.vh.nursery.HanoiRhymer;
 import edu.kis.vh.nursery.factory.Rhymersfactory;
@@ -8,22 +8,22 @@ import edu.kis.vh.nursery.factory.Rhymersfactory;
 public class DefaultRhymersFactory implements Rhymersfactory {
 
     @Override
-    public defaultCountingOutRhymer getStandardRhymer() {
-        return new defaultCountingOutRhymer();
+    public DefaultCountingOutRhymer getStandardRhymer() {
+        return new DefaultCountingOutRhymer();
     }
 
     @Override
-    public defaultCountingOutRhymer getFalseRhymer() {
-        return new defaultCountingOutRhymer();
+    public DefaultCountingOutRhymer getFalseRhymer() {
+        return new DefaultCountingOutRhymer();
     }
 
     @Override
-    public defaultCountingOutRhymer getFIFORhymer() {
+    public DefaultCountingOutRhymer getFIFORhymer() {
         return new FIFORhymer();
     }
 
     @Override
-    public defaultCountingOutRhymer getHanoiRhymer() {
+    public DefaultCountingOutRhymer getHanoiRhymer() {
         return new HanoiRhymer();
     }
 

--- a/src/main/java/edu/kis/vh/nursery/factory/Rhymersfactory.java
+++ b/src/main/java/edu/kis/vh/nursery/factory/Rhymersfactory.java
@@ -2,14 +2,14 @@ package edu.kis.vh.nursery.factory;
 
 import edu.kis.vh.nursery.defaultCountingOutRhymer;
 
-    public interface Rhymersfactory {
-    
-        public defaultCountingOutRhymer GetStandardRhymer();
-        
-        public defaultCountingOutRhymer GetFalseRhymer();
-        
-        public defaultCountingOutRhymer GetFIFORhymer();
-        
-        public defaultCountingOutRhymer GetHanoiRhymer();
-        
-    }
+public interface Rhymersfactory {
+
+    public defaultCountingOutRhymer GetStandardRhymer();
+
+    public defaultCountingOutRhymer GetFalseRhymer();
+
+    public defaultCountingOutRhymer GetFIFORhymer();
+
+    public defaultCountingOutRhymer GetHanoiRhymer();
+
+}

--- a/src/main/java/edu/kis/vh/nursery/factory/Rhymersfactory.java
+++ b/src/main/java/edu/kis/vh/nursery/factory/Rhymersfactory.java
@@ -1,15 +1,15 @@
 package edu.kis.vh.nursery.factory;
 
-import edu.kis.vh.nursery.defaultCountingOutRhymer;
+import edu.kis.vh.nursery.DefaultCountingOutRhymer;
 
 public interface Rhymersfactory {
 
-    public defaultCountingOutRhymer getStandardRhymer();
+    public DefaultCountingOutRhymer getStandardRhymer();
 
-    public defaultCountingOutRhymer getFalseRhymer();
+    public DefaultCountingOutRhymer getFalseRhymer();
 
-    public defaultCountingOutRhymer getFIFORhymer();
+    public DefaultCountingOutRhymer getFIFORhymer();
 
-    public defaultCountingOutRhymer getHanoiRhymer();
+    public DefaultCountingOutRhymer getHanoiRhymer();
 
 }

--- a/src/main/java/edu/kis/vh/nursery/factory/Rhymersfactory.java
+++ b/src/main/java/edu/kis/vh/nursery/factory/Rhymersfactory.java
@@ -4,12 +4,12 @@ import edu.kis.vh.nursery.defaultCountingOutRhymer;
 
 public interface Rhymersfactory {
 
-    public defaultCountingOutRhymer GetStandardRhymer();
+    public defaultCountingOutRhymer getStandardRhymer();
 
-    public defaultCountingOutRhymer GetFalseRhymer();
+    public defaultCountingOutRhymer getFalseRhymer();
 
-    public defaultCountingOutRhymer GetFIFORhymer();
+    public defaultCountingOutRhymer getFIFORhymer();
 
-    public defaultCountingOutRhymer GetHanoiRhymer();
+    public defaultCountingOutRhymer getHanoiRhymer();
 
 }

--- a/src/main/java/edu/kis/vh/nursery/list/IntLinkedList.java
+++ b/src/main/java/edu/kis/vh/nursery/list/IntLinkedList.java
@@ -2,8 +2,8 @@ package edu.kis.vh.nursery.list;
 
 public class IntLinkedList {
 
-    Node last;
-    int i;
+    private Node last;
+    private int i;
 
     public void push(int i) {
         if (last == null)

--- a/src/main/java/edu/kis/vh/nursery/list/IntLinkedList.java
+++ b/src/main/java/edu/kis/vh/nursery/list/IntLinkedList.java
@@ -9,9 +9,9 @@ public class IntLinkedList {
         if (last == null)
             last = new Node(i);
         else {
-            last.next = new Node(i);
-            last.next.prev = last;
-            last = last.next;
+            last.setNext(new Node(i));
+            last.getNext().setPrev(last);
+            last = last.getNext();
         }
     }
 
@@ -26,14 +26,14 @@ public class IntLinkedList {
     public int top() {
         if (isEmpty())
             return -1;
-        return last.value;
+        return last.getValue();
     }
 
     public int pop() {
         if (isEmpty())
             return -1;
-        int ret = last.value;
-        last = last.prev;
+        int ret = last.getValue();
+        last = last.getPrev();
         return ret;
     }
 

--- a/src/main/java/edu/kis/vh/nursery/list/Node.java
+++ b/src/main/java/edu/kis/vh/nursery/list/Node.java
@@ -8,5 +8,5 @@ public class Node {
     public Node(int i) {
         value = i;
     }
-    
+
 }

--- a/src/main/java/edu/kis/vh/nursery/list/Node.java
+++ b/src/main/java/edu/kis/vh/nursery/list/Node.java
@@ -14,10 +14,6 @@ public class Node {
         return value;
     }
 
-    public void setValue(int value) {
-        this.value = value;
-    }
-
     public Node getPrev() {
         return prev;
     }

--- a/src/main/java/edu/kis/vh/nursery/list/Node.java
+++ b/src/main/java/edu/kis/vh/nursery/list/Node.java
@@ -2,11 +2,35 @@ package edu.kis.vh.nursery.list;
 
 public class Node {
 
-    public int value;
-    public Node prev, next;
+    private int value;
+    private Node prev;
+    private Node next;
 
     public Node(int i) {
         value = i;
     }
 
+    public int getValue() {
+        return value;
+    }
+
+    public void setValue(int value) {
+        this.value = value;
+    }
+
+    public Node getPrev() {
+        return prev;
+    }
+
+    public void setPrev(Node prev) {
+        this.prev = prev;
+    }
+
+    public Node getNext() {
+        return next;
+    }
+
+    public void setNext(Node next) {
+        this.next = next;
+    }
 }

--- a/src/test/java/edu/kis/vh/nursery/RhymersDemo.java
+++ b/src/test/java/edu/kis/vh/nursery/RhymersDemo.java
@@ -10,8 +10,8 @@ class RhymersDemo {
     public static void main(String[] args) {
         Rhymersfactory factory = new DefaultRhymersFactory();
         
-        defaultCountingOutRhymer[] rhymers = { factory.GetStandardRhymer(), factory.GetFalseRhymer(),
-                factory.GetFIFORhymer(), factory.GetHanoiRhymer()};
+        defaultCountingOutRhymer[] rhymers = { factory.getStandardRhymer(), factory.getFalseRhymer(),
+                factory.getFIFORhymer(), factory.getHanoiRhymer()};
         
         for (int i = 1; i < 15; i++)
             for (int j = 0; j < 3; j++)

--- a/src/test/java/edu/kis/vh/nursery/RhymersDemo.java
+++ b/src/test/java/edu/kis/vh/nursery/RhymersDemo.java
@@ -1,6 +1,6 @@
 package edu.kis.vh.nursery;
 
-import edu.kis.vh.nursery.defaultCountingOutRhymer;
+import edu.kis.vh.nursery.DefaultCountingOutRhymer;
 import edu.kis.vh.nursery.HanoiRhymer;
 import edu.kis.vh.nursery.factory.DefaultRhymersFactory;
 import edu.kis.vh.nursery.factory.Rhymersfactory;
@@ -10,7 +10,7 @@ class RhymersDemo {
     public static void main(String[] args) {
         Rhymersfactory factory = new DefaultRhymersFactory();
         
-        defaultCountingOutRhymer[] rhymers = { factory.getStandardRhymer(), factory.getFalseRhymer(),
+        DefaultCountingOutRhymer[] rhymers = { factory.getStandardRhymer(), factory.getFalseRhymer(),
                 factory.getFIFORhymer(), factory.getHanoiRhymer()};
         
         for (int i = 1; i < 15; i++)

--- a/src/test/java/edu/kis/vh/nursery/RhymersJUnitTest.java
+++ b/src/test/java/edu/kis/vh/nursery/RhymersJUnitTest.java
@@ -7,7 +7,7 @@ public class RhymersJUnitTest {
 
     @Test
     public void testCountIn() {
-        defaultCountingOutRhymer rhymer = new defaultCountingOutRhymer();
+        DefaultCountingOutRhymer rhymer = new DefaultCountingOutRhymer();
         int testValue = 4;
         rhymer.countIn(testValue);
 
@@ -17,7 +17,7 @@ public class RhymersJUnitTest {
 
     @Test
     public void testCallCheck() {
-        defaultCountingOutRhymer rhymer = new defaultCountingOutRhymer();
+        DefaultCountingOutRhymer rhymer = new DefaultCountingOutRhymer();
         boolean result = rhymer.callCheck();
         Assert.assertEquals(true, result);
 
@@ -29,7 +29,7 @@ public class RhymersJUnitTest {
 
     @Test
     public void testIsFull() {
-        defaultCountingOutRhymer rhymer = new defaultCountingOutRhymer();
+        DefaultCountingOutRhymer rhymer = new DefaultCountingOutRhymer();
         final int STACK_CAPACITY = 12;
         for (int i = 0; i < STACK_CAPACITY; i++) {
             boolean result = rhymer.isFull();
@@ -43,7 +43,7 @@ public class RhymersJUnitTest {
 
     @Test
     public void testPeekaboo() {
-        defaultCountingOutRhymer rhymer = new defaultCountingOutRhymer();
+        DefaultCountingOutRhymer rhymer = new DefaultCountingOutRhymer();
         final int EMPTY_STACK_VALUE = -1;
 
         int result = rhymer.peekaboo();
@@ -60,7 +60,7 @@ public class RhymersJUnitTest {
 
     @Test
     public void testCountOut() {
-        defaultCountingOutRhymer rhymer = new defaultCountingOutRhymer();
+        DefaultCountingOutRhymer rhymer = new DefaultCountingOutRhymer();
         final int EMPTY_STACK_VALUE = -1;
 
         int result = rhymer.countOut();


### PR DESCRIPTION
9. Przeanalizuj atrybuty klas pod kątem widoczności (modyfikatory public, private, etc. ). Zastosuj możliwie
najmniejszą widoczność.
10. Wygeneruj getter dla pola total w klasie DefaultCountingOutRhymer (opcja Source → Generate Getters and
Setters).
11. Dokonaj hermetyzacji nieprywatnych atrybutów (polecenie Refactor → Encapsulate Field, w eclipse użyte z
opcją keep field reference, w IntelliJ opcja Use accesors even when field is accessible powinna być
odznaczona).
12. Usuń nieużywane setter (np. w Eclipse do analizy wywołań możesz użyć opcji Navigate → Open Call Hierarchy
(ctrl+alt+h)).
